### PR TITLE
Non-string map keys

### DIFF
--- a/itf/trace_test.go
+++ b/itf/trace_test.go
@@ -200,8 +200,7 @@ func TestUnmarshallRecordWithIntsAsMapKey(t *testing.T) {
 	assert.NotNil(t, map_)
 
 	for key := range map_ {
-		// key should be another map
-		assert.IsType(t, MapExprType{}, key)
+		assert.NotEqual(t, key, "a#bigint1b#bigint2")
 	}
 }
 

--- a/itf/trace_test.go
+++ b/itf/trace_test.go
@@ -130,7 +130,7 @@ func TestUnmarshallState(t *testing.T) {
 	assert.Equal(t, true, state.VarValues["var2"].Value)
 }
 
-func TestUnmarshallListAsMapKey(t *testing.T) {
+func TestUnmarshallRecordAsMapKey(t *testing.T) {
 	data := []byte(`
 	{
 			"currentState": {
@@ -165,6 +165,44 @@ func TestUnmarshallListAsMapKey(t *testing.T) {
 
 	state := states["currentState"].Value.(MapExprType)
 	assert.NotNil(t, state)
+}
+
+func TestUnmarshallRecordWithIntsAsMapKey(t *testing.T) {
+	data := []byte(`
+	{
+	"mapping": {
+		"#map": [
+			[
+				{
+					"a": {
+						"#bigint": "1"
+					},
+					"b": {
+						"#bigint": "2"
+					}
+				},
+				{
+					"#bigint": "3"
+				}
+			]
+		]
+	}
+	}`)
+
+	var expr Expr
+	err := json.Unmarshal(data, &expr)
+	assert.Nil(t, err)
+
+	mapping := expr.Value.(MapExprType)
+	assert.NotNil(t, mapping)
+
+	map_ := mapping["mapping"].Value.(MapExprType)
+	assert.NotNil(t, map_)
+
+	for key := range map_ {
+		// key should be another map
+		assert.IsType(t, MapExprType{}, key)
+	}
 }
 
 func TestUnmarshallTrace(t *testing.T) {

--- a/itf/trace_test.go
+++ b/itf/trace_test.go
@@ -130,6 +130,43 @@ func TestUnmarshallState(t *testing.T) {
 	assert.Equal(t, true, state.VarValues["var2"].Value)
 }
 
+func TestUnmarshallListAsMapKey(t *testing.T) {
+	data := []byte(`
+	{
+			"currentState": {
+				"#map": [
+					[
+						{
+							"validatorSet": {
+								"#map": [
+									[
+										"node1",
+										{
+											"#bigint": "100"
+										}
+									]
+								]
+							}
+						},
+						{
+							"#bigint": "1209600"
+						}
+					]
+				]
+			}
+	}`)
+
+	var expr Expr
+	err := json.Unmarshal(data, &expr)
+	assert.Nil(t, err)
+
+	states := expr.Value.(MapExprType)
+	assert.NotNil(t, states)
+
+	state := states["currentState"].Value.(MapExprType)
+	assert.NotNil(t, state)
+}
+
 func TestUnmarshallTrace(t *testing.T) {
 	data := []byte(`{
 		"#meta": {


### PR DESCRIPTION

The PR has two test cases for non-string map keys.

Both of them were generated from itf traces output by Quint, but I've minimized them to focus on the problematic parts.